### PR TITLE
Update `Switch Mode` hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ There are two modes available which each mode will represents a different contro
 
 ## Mode
 
-- `Alt+K` - Switch mode to **Normal Mode**. This allows you to control the cursor with your keyboard.
-- `Alt+L` - Switch mode to **Insert Mode**. This allows you to type reguarly with your keyboard.
+- `Shift+Alt+K` - Switch mode to **Normal Mode**. This allows you to control the cursor with your keyboard.
+- `Shift+Alt+L` - Switch mode to **Insert Mode**. This allows you to type reguarly with your keyboard.
 
 ### Cursor
 

--- a/quick_mouse.ahk
+++ b/quick_mouse.ahk
@@ -169,8 +169,8 @@ ScrollLeft() {
     Click, WheelLeft
 }
 
-!k:: SwitchMode(False, True)
-!l:: SwitchMode(False, False)
++!k:: SwitchMode(False, True)
++!l:: SwitchMode(False, False)
 
 #If (NORMAL_MODE)
 w:: Return


### PR DESCRIPTION
Added an extra `Shift` key to resolve a minor bug where if you accidentally press the `Alt` key, it'll show up some browser popup (at least in Opera GX)